### PR TITLE
fix: treat GitHub tokens as opaque

### DIFF
--- a/src/dotnet/Logger/IGitHubApi.cs
+++ b/src/dotnet/Logger/IGitHubApi.cs
@@ -24,7 +24,7 @@ internal sealed class GitHubApi : IGitHubApi
         _params = parameters;
         Output = output;
         IsGitHubActions = _params.CI.asBool() && _params.GITHUB_ACTIONS.asBool();
-        _isOctokitEnabled = IsGitHubActions && _params.GITHUB_TOKEN?.Length == 40 && _params.GITHUB_SHA?.Length > 0;
+        _isOctokitEnabled = IsGitHubActions && !string.IsNullOrEmpty(_params.GITHUB_TOKEN) && _params.GITHUB_SHA?.Length > 0;
         _api = _isOctokitEnabled
             ? new(() => {
                 if (api != null)

--- a/src/dotnet/Logger/Logger.cs
+++ b/src/dotnet/Logger/Logger.cs
@@ -47,11 +47,6 @@ public class GitHubLogger : ITestLoggerWithParameters
             _gh.Output.Warning("This isn't a GitHub Actions environment. Logger won't do anything. You can force it with 'CI=1;GITHUB_ACTIONS=1' parameters or env variables.");
             return;
         }
-        if (!string.IsNullOrEmpty(_params.GITHUB_TOKEN) && _params.GITHUB_TOKEN.Length != 40)
-        {
-            _gh.Output.Warning("GITHUB_TOKEN is an unsupported token (length != 40). Logger won't do anything.");
-            return;
-        }
         var workspace = !string.IsNullOrWhiteSpace(_params.GITHUB_WORKSPACE)
             ? _params.GITHUB_WORKSPACE
             : Environment.CurrentDirectory;


### PR DESCRIPTION
GitHub is rolling out a new variable-length stateless format for GitHub App installation tokens, including Actions-issued `GITHUB_TOKEN`: https://github.blog/changelog/2026-04-24-notice-about-upcoming-new-format-for-github-app-installation-tokens/

This removes the hardcoded 40-character token check and treats `GITHUB_TOKEN` as an opaque value. The logger now enables Octokit whenever a token is present and `GITHUB_SHA` is available, without making assumptions about token length or format.